### PR TITLE
Highlight dependency parameters

### DIFF
--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/AttackTableShipEntry.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/AttackTableShipEntry.razor
@@ -1,4 +1,6 @@
-﻿@using Blazored.Modal;
+﻿@using VirtualAttackTableLib.TargetShipParameter
+@using BlazorWASMAttackTable.Client.Interactions.Common;
+@using Blazored.Modal;
 @using Blazored.Modal.Services;
 @using CallbackList
 @using BlazorWASMAttackTable.Client.Interactions
@@ -8,25 +10,25 @@
 @inherits SubscriptionDisposingElement
 
 <tr id="attack-table-entry-row">
-    <td title="Set absolute dimensions from image" @onclick="RequestShipDimensionsFromImage">
+    <td style="height: inherit;" title="Set absolute dimensions from image" @onclick="RequestShipDimensionsFromImage">
         <img id="attack-table-row-element" style="aspect-ratio: 2/1; object-fit: contain;" src="@BlazorAttackTableLib.GetShipImagePath(TargetShip.TargetShip.Data.TypeName)" />
     </td>
 
-    <td>@TargetShip.TargetShip.Data.TypeName.Replace('_', ' ')</td>
+    <td style="height: inherit;">@TargetShip.TargetShip.Data.TypeName.Replace('_', ' ')</td>
 
-    <td><FloatParameterCell Interaction="TargetShip.Bearing"/></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.Bearing" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.AbsoluteHeight"/></td>
-    <td><FloatParameterCell Interaction="TargetShip.VisibleHeight"/></td>
-    <td><FloatParameterCell Interaction="TargetShip.AbsoluteLength"/></td>
-    <td><FloatParameterCell Interaction="TargetShip.VisibleLength"/></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.AbsoluteHeight" OwningEntry="this" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.VisibleHeight" OwningEntry="this" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.AbsoluteLength" OwningEntry="this" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.VisibleLength" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.TargetRange"/></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.TargetRange" OwningEntry="this" /></td>
 
-    <td>
+    <td style="height: inherit;">
         <div class="flexrow" style="height: 100px;">
             <div style="width: 75%; justify-content: center; display: flex;">
-                <FloatParameterCell Interaction="TargetShip.AoB"/>
+                <FloatParameterCell Interaction="TargetShip.AoB" OwningEntry="this" />
             </div>
             <div style="width: 25%;">
                 <SelectAoBQuarter Parameter="TargetShip.AoB.Parameter"/>
@@ -34,22 +36,26 @@
         </div>
     </td>
 
-    <td><FloatParameterCell Interaction="TargetShip.HullTime"/></td>
-    <td><FloatParameterCell Interaction="TargetShip.OneDegreeTime"/></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.HullTime" OwningEntry="this" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.OneDegreeTime" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.TargetSpeed" /></td>
-    <td><FloatParameterCell Interaction="TargetShip.AngularSpeed" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.TargetSpeed" OwningEntry="this" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.AngularSpeed" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.TorpedoSpeed"/></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.TorpedoSpeed" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.BoatSpeed" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.BoatSpeed" OwningEntry="this" /></td>
 
-    <td><FloatParameterCell Interaction="TargetShip.LeadAngle" /></td>
+    <td style="height: inherit;"><FloatParameterCell Interaction="TargetShip.LeadAngle" OwningEntry="this" /></td>
 
-    <td title="Remove target" @onclick="RemoveThisTarget"><img src="images/Cross.svg" style="object-fit: contain; height: 100%; width: 100%;"/></td>
+    <td style="height: inherit;" title="Remove target" @onclick="RemoveThisTarget"><img src="images/Cross.svg" style="object-fit: contain; height: 100%; width: 100%;" /></td>
 </tr>
 
 @code {
+    #region Fields
+    private IParameterDefinition? _definitionToHighlightParameters;
+    #endregion
+
     #region Properties
     [CascadingParameter]
     public IModalService Modal { get; set; } = null!;
@@ -59,9 +65,32 @@
 
     [Parameter, EditorRequired]
     public AttackTableInteraction AttackTable { get; set; } = null!;
+
+    public IParameterDefinition? DefinitionToHighlightParameters
+    {
+        get
+        {
+            return _definitionToHighlightParameters;
+        }
+        set
+        {
+            if (_definitionToHighlightParameters != value)
+            {
+                _definitionToHighlightParameters = value;
+                DefinitionToHighlightParametersChanged();
+            }
+        }
+    }
+
+    public ValueInteraction<IReadOnlySet<IParameter>> ParametersToHighlight { get; } = new(new HashSet<IParameter>());
     #endregion
 
     #region Methods
+    protected override void OnParametersSet()
+    {
+        ParametersToHighlight.Value = new HashSet<IParameter>();
+    }
+
     private void RemoveThisTarget()
     {
         AttackTable.RemoveTargetShip(TargetShip);
@@ -82,6 +111,18 @@
         };
 
         Modal.Show<ObservationDimensionsFromShipImage>("Select Dimensions for Size Observation", modalParameters, modalOptions);
+    }
+
+    private void DefinitionToHighlightParametersChanged()
+    {
+        if (DefinitionToHighlightParameters == null)
+        {
+            ParametersToHighlight.Value = new HashSet<IParameter>();
+        }
+        else
+        {
+            ParametersToHighlight.Value = new HashSet<IParameter>(DefinitionToHighlightParameters.DependencyParameters);
+        }
     }
     #endregion
 }

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor
@@ -3,10 +3,16 @@
 
 @typeparam TParameter
 @typeparam TDefinitionKey
+
+@implements IAsyncDisposable
 @inherits SubscriptionDisposingElement
 
+@inject IJSRuntime JS;
+
 <div class="flexcolumn" style="background-color: @BackgroundStyleEntry; width: 100%; height: 100%; justify-content: center;"
-    @onmouseenter="OnMouseEnterThisCell" @onmouseleave="OnMouseLeaveThisCell">
+    @onmouseenter="OnMouseEnterThisCell" @onmouseleave="OnMouseLeaveThisCell"
+    @onclick="OnMouseClick"
+    @ref="RootDiv">
     <div class="flexcolumn" style="margin: 5px; width: calc(100% - 10px); height: auto;">
         <Combobox Interaction="Interaction.DefinitionKeySelection"/>
 
@@ -25,5 +31,7 @@
 {
     private string BadInputStyleAffix => BadInput ? "background-color: rgb(250, 250, 0, 0.8);" : "";
 
-    private string BackgroundStyleEntry => Highlight ? "rgb(120, 120, 255)" : "transparent";
+    private string BackgroundStyleEntry => Highlight ? "rgb(0, 100, 200, 0.5)" : "transparent";
+
+    private ElementReference RootDiv { get; set; }
 }

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor
@@ -5,20 +5,25 @@
 @typeparam TDefinitionKey
 @inherits SubscriptionDisposingElement
 
-<div class="flexcolumn" style="margin: 5px; width: calc(100% - 10px); height: auto; justify-content: center;">
-    <Combobox Interaction="Interaction.DefinitionKeySelection"/>
+<div class="flexcolumn" style="background-color: @BackgroundStyleEntry; width: 100%; height: 100%; justify-content: center;"
+    @onmouseenter="OnMouseEnterThisCell" @onmouseleave="OnMouseLeaveThisCell">
+    <div class="flexcolumn" style="margin: 5px; width: calc(100% - 10px); height: auto;">
+        <Combobox Interaction="Interaction.DefinitionKeySelection"/>
 
-    @if (Interaction.CanSetArbitraryValue)
-    {
-        <input @bind="DisplayValue" @bind:event="oninput" style="@BadInputStyleAffix" />
-    }
-    else
-    {
-        <input @bind="DisplayValue" disabled />
-    }
+        @if (Interaction.CanSetArbitraryValue)
+        {
+            <input @bind="DisplayValue" @bind:event="oninput" style="@BadInputStyleAffix" />
+        }
+        else
+        {
+            <input @bind="DisplayValue" disabled />
+        }
+    </div>
 </div>
 
 @code
 {
-    private string BadInputStyleAffix => BadInput ? "background: rgb(250, 250, 0, 0.8);" : "";
+    private string BadInputStyleAffix => BadInput ? "background-color: rgb(250, 250, 0, 0.8);" : "";
+
+    private string BackgroundStyleEntry => Highlight ? "rgb(120, 120, 255)" : "transparent";
 }

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor.js
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/FloatParameterCell.razor.js
@@ -1,0 +1,4 @@
+export function IsPointOver(element, x, y) {
+    const rect = element.getBoundingClientRect();
+    return (x > rect.left && x < rect.right && y > rect.top && y < rect.bottom)
+}

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/UnitsSelection.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/AttackTableElements/UnitsSelection.razor
@@ -1,6 +1,6 @@
 ﻿@using BlazorWASMAttackTable.Client.Interactions.Options;
 
-<tr style="background: rgb(220, 220, 220); position: sticky; top: 0;">
+<tr style="background: rgb(220, 220, 220); position: sticky; top: 0; z-index: 1000;">
     <td style="width: 200px;"/>
     <td style="width: 100px;">Type Code</td>
 

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor
@@ -1,62 +1,136 @@
-﻿@using BlazorWASMAttackTable.Shared.StatefulEnumeration
-@using BlazorWASMAttackTable.Client.Interactions.Options;
+﻿@using BlazorWASMAttackTable.Client.Interactions.Options;
+@using BlazorWASMAttackTable.Client.Elements.SubscriptionDisposal;
 
-<select @onchange="OnChange">
-    @if (Interaction.AllowNoOption)
+@inherits SubscriptionDisposingElement
+
+<div @onclick="OnMainBoxClick" class="combobox-main-box" style="z-index: @ZIndex">
+    <div class="combobox-main-box-text">
+    @if (Interaction.SelectedOption.Value == null)
     {
-        <option value="0">- None -</option>
+        @NoOption
     }
-
-    @{
-        int optionCode = 1;
-        foreach (IOptionInteraction optionInteraction in Interaction.Options)
-        {
-            if (optionInteraction.IsSelected)
-            {
-                <option value="@optionCode" title="@optionInteraction.OptionDescription" selected>@optionInteraction.OptionName</option>
-            }
-            else
-            {
-                <option value="@optionCode" title="@optionInteraction.OptionDescription">@optionInteraction.OptionName</option>
-            }
-
-            optionCode++;
-        }
+    else
+    {
+        @Interaction.SelectedOption.Value.OptionName
     }
-</select>
+    </div>
+
+    @if (DisplayDropdown)
+    {
+        <div class="combobox-dropdown-box" @onclick:stopPropagation="true">
+            @if (Interaction.AllowNoOption)
+            {
+                <div class="combobox-dropdown-entry" @onclick="OnNoOptionClick">@NoOption</div>
+            }
+
+            @foreach (IOptionInteraction option in Interaction.Options)
+            {
+                <div class="combobox-dropdown-entry" @onclick="() => OnOptionClick(option)"
+                    @onmouseenter="() => OnMouseEnterOption(option)"
+                    @onmouseleave="() => OnMouseLeaveOption(option)"
+                >
+                    @option.OptionName
+                </div>
+            }
+        </div>
+    }
+</div>
 
 @code {
+    #region Consts
+    private const string NoOption = "--No Option--";
+    #endregion
+
+    #region Fields
+    private bool _displayDropdown;
+    #endregion
+
+    #region Properties
     [Parameter, EditorRequired]
     public IListForSingleOption Interaction { get; set; } = null!;
 
-    private Dictionary<int, IOptionInteraction> OptionsMap { get; } = new();
+    private bool DisplayDropdown
+    {
+        get
+        {
+            return _displayDropdown;
+        }
+        set
+        {
+            if (_displayDropdown != value)
+            {
+                _displayDropdown = value;
 
+                if (!_displayDropdown)
+                {
+                    ClearPreviewedOption();
+                }
+
+                StateHasChanged();
+            }
+        }
+    }
+
+    private IOptionInteraction? PreviewedOption { get; set; }
+
+    private int ZIndex => DisplayDropdown ? 100 : 0;
+    #endregion
+
+    #region Methods
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
 
-        OptionsMap.Clear();
-
-        Interaction.Options.ForEach(
-            (option, index) => OptionsMap.Add(index, option),
-            startIndex: 1).Enumerate();
+        Subscribe(Interaction.SelectedOption.ValueChanged, OnSelectedOptionChanged);
     }
 
-    private void OnChange(ChangeEventArgs e)
+    private void OnSelectedOptionChanged(IOption? option)
     {
-        if (int.TryParse(e.Value as string, out int optionCode))
-        {
-            if (optionCode == 0 && Interaction.AllowNoOption)
-            {
-                Interaction.SelectNoOption();
-                return;
-            }
+        StateHasChanged();
+    }
 
-            if (OptionsMap.TryGetValue(optionCode, out IOptionInteraction? option) && option.IsSelected == false)
-            {
-                option.Toggle();
-                return;
-            }
+    private void OnMainBoxClick()
+    {
+        DisplayDropdown = !DisplayDropdown;
+    }
+
+    private void OnNoOptionClick()
+    {
+        DisplayDropdown = false;
+        Interaction.SelectNoOption();
+    }
+
+    private void OnOptionClick(IOptionInteraction option)
+    {
+        DisplayDropdown = false;
+
+        if (!option.IsSelected)
+        {
+            option.Toggle();
         }
     }
+
+    private void OnMouseEnterOption(IOptionInteraction option)
+    {
+        PreviewOption(option);
+    }
+
+    private void OnMouseLeaveOption(IOptionInteraction option)
+    {
+        if (option == PreviewedOption)
+            ClearPreviewedOption();
+    }
+
+    private void PreviewOption(IOptionInteraction option)
+    {
+        PreviewedOption = option;
+        option.Preview(true);
+    }
+
+    private void ClearPreviewedOption()
+    {
+        PreviewedOption?.Preview(false);
+        PreviewedOption = null;
+    }
+    #endregion
 }

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor.css
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor.css
@@ -1,0 +1,38 @@
+﻿.combobox-main-box {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+
+    background-color: white;
+    border-radius: 6px;
+    border: 1px solid black;
+}
+
+.combobox-main-box-text {
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+}
+
+.combobox-dropdown-box {
+    position: absolute;
+    top: 100%;
+    left: 0;
+
+    display: flex;
+    flex-direction: column;
+
+    background-color: white;
+    border: 1px solid blue;
+    min-width: 100%;
+}
+
+.combobox-dropdown-entry {
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+}
+
+    .combobox-dropdown-entry:hover {
+        background-color: rgb(0, 100, 200, 0.5);
+    }

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/ComboboxOld.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/ComboboxOld.razor
@@ -1,0 +1,62 @@
+﻿@using BlazorWASMAttackTable.Shared.StatefulEnumeration
+@using BlazorWASMAttackTable.Client.Interactions.Options;
+
+<select @onchange="OnChange">
+    @if (Interaction.AllowNoOption)
+    {
+        <option value="0">- None -</option>
+    }
+
+    @{
+        int optionCode = 1;
+        foreach (IOptionInteraction optionInteraction in Interaction.Options)
+        {
+            if (optionInteraction.IsSelected)
+            {
+                <option value="@optionCode" title="@optionInteraction.OptionDescription" selected>@optionInteraction.OptionName</option>
+            }
+            else
+            {
+                <option value="@optionCode" title="@optionInteraction.OptionDescription">@optionInteraction.OptionName</option>
+            }
+
+            optionCode++;
+        }
+    }
+</select>
+
+@code {
+    [Parameter, EditorRequired]
+    public IListForSingleOption Interaction { get; set; } = null!;
+
+    private Dictionary<int, IOptionInteraction> OptionsMap { get; } = new();
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        OptionsMap.Clear();
+
+        Interaction.Options.ForEach(
+            (option, index) => OptionsMap.Add(index, option),
+            startIndex: 1).Enumerate();
+    }
+
+    private void OnChange(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value as string, out int optionCode))
+        {
+            if (optionCode == 0 && Interaction.AllowNoOption)
+            {
+                Interaction.SelectNoOption();
+                return;
+            }
+
+            if (OptionsMap.TryGetValue(optionCode, out IOptionInteraction? option) && option.IsSelected == false)
+            {
+                option.Toggle();
+                return;
+            }
+        }
+    }
+}

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/SubscriptionDisposal/ISubscriptionDisposingElement.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/SubscriptionDisposal/ISubscriptionDisposingElement.cs
@@ -7,7 +7,7 @@ namespace BlazorWASMAttackTable.Client.Elements.SubscriptionDisposal
     {
         private static ConditionalWeakTable<ISubscriptionDisposingElement, SubscriptionContainer> Containers = new();
 
-        public ISubscriptionHandle Subscribe<TDelegate>(ICallbackListManager<TDelegate> callbackListManager, TDelegate @delegate)
+        public ISubscriptionHandle Subscribe<TDelegate>(ISubscribableCallbackListManager<TDelegate> callbackListManager, TDelegate @delegate)
             where TDelegate : Delegate
         {
             ISubscriptionHandle result = callbackListManager.Subscribe(@delegate);
@@ -15,7 +15,7 @@ namespace BlazorWASMAttackTable.Client.Elements.SubscriptionDisposal
             return result;
         }
 
-        public ISubscriptionHandle WeakSubscribe<TDelegate>(ICallbackListManager<TDelegate> callbackListManager, WeakSubscriptionStorage weakSubscriptionStorage, TDelegate @delegate)
+        public ISubscriptionHandle WeakSubscribe<TDelegate>(ISubscribableCallbackListManager<TDelegate> callbackListManager, WeakSubscriptionStorage weakSubscriptionStorage, TDelegate @delegate)
             where TDelegate : Delegate
         {
             ISubscriptionHandle result = callbackListManager.WeakSubscribe(weakSubscriptionStorage, @delegate);

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/SubscriptionDisposal/SubscriptionDisposingElement.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/SubscriptionDisposal/SubscriptionDisposingElement.cs
@@ -12,13 +12,13 @@ namespace BlazorWASMAttackTable.Client.Elements.SubscriptionDisposal
             await base.SetParametersAsync(parameters);
         }
 
-        protected ISubscriptionHandle Subscribe<TDelegate>(ICallbackListManager<TDelegate> callbackListManager, TDelegate @delegate)
+        protected ISubscriptionHandle Subscribe<TDelegate>(ISubscribableCallbackListManager<TDelegate> callbackListManager, TDelegate @delegate)
             where TDelegate : Delegate
         {
             return (this as ISubscriptionDisposingElement).Subscribe(callbackListManager, @delegate);
         }
 
-        protected ISubscriptionHandle WeakSubscribe<TDelegate>(ICallbackListManager<TDelegate> callbackListManager, WeakSubscriptionStorage weakSubscriptionStorage, TDelegate @delegate)
+        protected ISubscriptionHandle WeakSubscribe<TDelegate>(ISubscribableCallbackListManager<TDelegate> callbackListManager, WeakSubscriptionStorage weakSubscriptionStorage, TDelegate @delegate)
             where TDelegate : Delegate
         {
             return (this as ISubscriptionDisposingElement).WeakSubscribe(callbackListManager, weakSubscriptionStorage, @delegate);

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/AlteredUnitParameterInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/AlteredUnitParameterInteraction.cs
@@ -17,7 +17,7 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
 
         #region Properties
         private IListForSingleOption<IUnit> AlteredUnitSource { get; }
-        protected IUnit CurrentUnit => AlteredUnitSource.SelectedOption?.Value ??
+        protected IUnit CurrentUnit => AlteredUnitSource.SelectedOption.Value?.Value ??
             throw (new InvalidOperationException($"{GetType()} can not get current unit because " +
                 $"its unit source has {nameof(AlteredUnitSource.SelectedOption)} of null."));
         public TParameter Parameter { get; }
@@ -85,13 +85,13 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
             IEnumerable<Option<TDefinitionKey>> options, IListForSingleOption<IUnit> unitSource)
         {
             AlteredUnitSource = unitSource;
-            AlteredUnitSource.SelectedOptionChanged.Subscribe(OnUnitChanged);
+            AlteredUnitSource.SelectedOption.ValueChanged.Subscribe(OnUnitChanged);
 
             Parameter = parameter;
             Parameter.ParameterChanged.Subscribe(OnParameterChanged);
 
             DefinitionKeySelection = new(options, "Definition");
-            DefinitionKeySelection.SelectedOptionChanged.Subscribe(SetDefinitionKey);
+            DefinitionKeySelection.SelectedOption.ValueChanged.Subscribe(SetDefinitionKey);
         }
         #endregion
 
@@ -113,9 +113,9 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
             }
         }
 
-        private void SetDefinitionKey(Option<TDefinitionKey>? _)
+        private void SetDefinitionKey(IOption<TDefinitionKey>? _)
         {
-            Parameter.ActiveDefinitionKey = DefinitionKeySelection.SelectedOption!.Value;
+            Parameter.ActiveDefinitionKey = DefinitionKeySelection.SelectedOption.Value!.Value;
         }
 
         private void OnUnitChanged(IOption<IUnit>? _)

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/TargetShipAlteredUnitsWrap.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/TargetShipAlteredUnitsWrap.cs
@@ -67,8 +67,8 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
             AbsoluteLength = new(TargetShip.AbsoluteLengthMeters, GenerateOptions(TargetShip.AbsoluteLengthMeters.GetPresentDefinitionKeys(), _absoluteLengthDefinitionDescriptions), unitsSelection.AbsoluteLength);
             VisibleLength = new(TargetShip.VisibleLengthRadians, GenerateOptions(TargetShip.VisibleLengthRadians.GetPresentDefinitionKeys()), unitsSelection.VisibleLength);
 
-            ArbitraryAbsoluteHeightMeters = AbsoluteHeight.Parameter.AllDefinitions.OfType<ArbitraryValueParameterDefinition<float>>().First();
-            ArbitraryAbsoluteLengthMeters = AbsoluteLength.Parameter.AllDefinitions.OfType<ArbitraryValueParameterDefinition<float>>().First();
+            ArbitraryAbsoluteHeightMeters = AbsoluteHeight.Parameter.AllDefinitions.Values.OfType<ArbitraryValueParameterDefinition<float>>().First();
+            ArbitraryAbsoluteLengthMeters = AbsoluteLength.Parameter.AllDefinitions.Values.OfType<ArbitraryValueParameterDefinition<float>>().First();
 
             TargetRange = new(TargetShip.TargetRangeMeters, GenerateOptions(TargetShip.TargetRangeMeters.GetPresentDefinitionKeys(), _targetRangeDefinitionDescriptions), unitsSelection.TargetRange);
 

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Common/ValueInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Common/ValueInteraction.cs
@@ -1,8 +1,16 @@
-﻿using CallbackList;
+﻿using BlazorWASMAttackTable.Client.Interactions.Options;
+using CallbackList;
 
 namespace BlazorWASMAttackTable.Client.Interactions.Common
 {
-    public class ValueInteraction<T>
+    public interface IReadOnlyValueInteraction<out T>
+    {
+        public T Value { get; }
+
+        public ISubscribableCallbackListManager<Action<T>> ValueChanged { get; }
+    }
+
+    public class ValueInteraction<T> : IReadOnlyValueInteraction<T>
     {
         #region Fields
         private T _value;
@@ -25,6 +33,8 @@ namespace BlazorWASMAttackTable.Client.Interactions.Common
         {
             get;
         } = new();
+
+        ISubscribableCallbackListManager<Action<T>> IReadOnlyValueInteraction<T>.ValueChanged => ValueChanged;
         //public event Action<T>? ValueChanged;
         #endregion
 

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/IdentifyShipInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/IdentifyShipInteraction.cs
@@ -33,8 +33,7 @@ namespace BlazorWASMAttackTable.Client.Interactions
             private init
             {
                 _superstructure = value;
-                _superstructure.SelectedOptionChanged.Subscribe(OnFilterValueChanged);
-                //_superstructure.SelectedOptionChanged += OnFilterValueChanged;
+                _superstructure.SelectedOption.ValueChanged.Subscribe(OnFilterValueChanged);
             }
         }
 
@@ -47,8 +46,7 @@ namespace BlazorWASMAttackTable.Client.Interactions
             private init
             {
                 _enginePlacement = value;
-                _enginePlacement.SelectedOptionChanged.Subscribe(OnFilterValueChanged);
-                //_enginePlacement.SelectedOptionChanged += OnFilterValueChanged;
+                _enginePlacement.SelectedOption.ValueChanged.Subscribe(OnFilterValueChanged);
             }
         }
 
@@ -208,8 +206,8 @@ namespace BlazorWASMAttackTable.Client.Interactions
         {
             TargetShipData targetShipData = wrap.TargetShipData;
 
-            if (Superstructure.SelectedOption != null && Superstructure.SelectedOption.Value != targetShipData.Superstructure) return false;
-            if (EnginePlacement.SelectedOption != null && EnginePlacement.SelectedOption.Value != targetShipData.EnginePlacement) return false;
+            if (Superstructure.SelectedOption.Value != null && Superstructure.SelectedOption.Value.Value != targetShipData.Superstructure) return false;
+            if (EnginePlacement.SelectedOption.Value != null && EnginePlacement.SelectedOption.Value.Value != targetShipData.EnginePlacement) return false;
 
             if (BowIsland.Value != null && BowIsland.Value != targetShipData.IslandsPositions.HasFlag(IslandsPositions.Bow)) return false;
             if (MidIsland.Value != null && MidIsland.Value != targetShipData.IslandsPositions.HasFlag(IslandsPositions.Mid)) return false;

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListOfOptions.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListOfOptions.cs
@@ -21,13 +21,15 @@
         #region Constructors
         public ListOfOptions(IEnumerable<Option<TOption>> options, string interactionHeader)
         {
-            Options = options.Select(option => new OptionInteraction<TOption>(option, ToggleOption)).ToList();
+            Options = options.Select(option => new OptionInteraction<TOption>(option, ToggleOption, this)).ToList();
             InteractionHeader = interactionHeader;
         }
         #endregion
 
         #region Methods
         protected abstract void ToggleOption(OptionInteraction<TOption> option);
+
+        public virtual void PreviewOption(Option<TOption> option, bool preview) { }
         #endregion
     }
 

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/OptionInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/OptionInteraction.cs
@@ -32,17 +32,20 @@ namespace BlazorWASMAttackTable.Client.Interactions.Options
         {
             get;
         } = new();
-        //public event Action? StateChanged;
+
+        private ListOfOptions<TOption> OwningList { get; }
         #endregion
 
         #region Constructors
-        public OptionInteraction(Option<TOption> option, Action<OptionInteraction<TOption>> toggleCall)
+        public OptionInteraction(Option<TOption> option, Action<OptionInteraction<TOption>> toggleCall, ListOfOptions<TOption> owningList)
         {
             _option = option;
 
             ToggleCall = () => toggleCall(this);
 
             IsSelected = false;
+
+            OwningList = owningList;
         }
         #endregion
 
@@ -57,6 +60,11 @@ namespace BlazorWASMAttackTable.Client.Interactions.Options
             IsSelected = isSelected;
             StateChanged.CreateFireCall()?.Invoke();
         }
+
+        public void Preview(bool preview)
+        {
+            OwningList.PreviewOption(Option, preview);
+        }
         #endregion
     }
 
@@ -66,6 +74,7 @@ namespace BlazorWASMAttackTable.Client.Interactions.Options
         public string OptionDescription { get; }
         public bool IsSelected { get; }
         void Toggle();
+        void Preview(bool preview);
 
         //event Action? StateChanged;
         CallbackListManager StateChanged { get; }

--- a/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/AoBParameter.cs
+++ b/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/AoBParameter.cs
@@ -35,7 +35,7 @@ namespace VirtualAttackTableLib.TargetShipParameter
         #region Methods
         private void OnAoBQuarterChanged()
         {
-            foreach(IParameterDefinition definition in AllDefinitions)
+            foreach(IParameterDefinition definition in AllDefinitions.Values)
             {
                 definition.Update();
             }

--- a/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/MultipleDefinitionParameter.cs
+++ b/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/MultipleDefinitionParameter.cs
@@ -68,7 +68,7 @@ namespace VirtualAttackTableLib.TargetShipParameter
             init;
         } = new();
 
-        public IEnumerable<ParameterDefinition<TValue>> AllDefinitions => Definitions.Values;
+        public IReadOnlyDictionary<TDefinitionKey, ParameterDefinition<TValue>> AllDefinitions => Definitions;
 
         /// <summary>
         /// Fired when a different <see cref="ActiveDefinition"/> is set or its <see cref="ParameterDefinition{TValue}.CurrentState"/> or <see cref="ParameterDefinition{TValue}.CurrentValue"/> are changed.

--- a/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/ParameterDefinition.cs
+++ b/Source/VirtualAttackTable/VirtualAttackTableLib/TargetShipParameter/ParameterDefinition.cs
@@ -10,6 +10,8 @@ namespace VirtualAttackTableLib.TargetShipParameter
     public interface IParameterDefinition
     {
         void Update();
+
+        IReadOnlyList<IParameter> DependencyParameters { get; }
     }
 
     public class ParameterDefinition<TValue> : IParameterDefinition


### PR DESCRIPTION
- Dependency parameters are now highlighted when hovering over a parameter cell or a parameter definition option in the definition selection.
- Replaced Combobox with a custom implementation to support mouse events that were needed to highlight dependency parameters for hovered options. It looks different and does not close if it loses focus. 