### PR TITLE
Value to arbitrary

### DIFF
--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Elements/Common/Combobox.razor
@@ -32,6 +32,13 @@
                     @option.OptionName
                 </div>
             }
+
+            @foreach (FakeOptionInteraction fakeOption in Interaction.FakeOptionInteractions)
+            {
+                <div class="combobox-dropdown-entry" @onclick="() => OnFakeOptionClick(fakeOption)">
+                    @fakeOption.OptionName
+                </div>
+            }
         </div>
     }
 </div>
@@ -108,6 +115,13 @@
         {
             option.Toggle();
         }
+    }
+
+    private void OnFakeOptionClick(FakeOptionInteraction fakeOptionInteraction)
+    {
+        DisplayDropdown = false;
+
+        fakeOptionInteraction.TriggerAction();
     }
 
     private void OnMouseEnterOption(IOptionInteraction option)

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/AlteredUnitParameterInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/AttackTableInteractions/AlteredUnitParameterInteraction.cs
@@ -61,6 +61,8 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
             }
         }
 
+        private IOptionInteraction? ArbitraryDefinitionSelectionOption { get; }
+
         private ParameterDefinitionState DefinitionState
         {
             get
@@ -93,6 +95,18 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
             DefinitionKeySelection = new(options, "Definition");
             DefinitionKeySelection.Options.FirstOrDefault(opt => opt.Value.Equals(parameter.ActiveDefinitionKey))?.Toggle();
             DefinitionKeySelection.SelectedOption.ValueChanged.Subscribe(SetDefinitionKey);
+
+            KeyValuePair<TDefinitionKey, ParameterDefinition<float>>? arbitraryDefinitionDicionaryPair =
+                parameter.AllDefinitions.
+                Select(pair => (KeyValuePair<TDefinitionKey, ParameterDefinition<float>>?)pair).
+                FirstOrDefault(pair => pair?.Value is ArbitraryValueParameterDefinition<float>);
+
+            if (arbitraryDefinitionDicionaryPair != null)
+            {
+                TDefinitionKey arbitraryDefinitionKey = arbitraryDefinitionDicionaryPair.Value.Key;
+
+                ArbitraryDefinitionSelectionOption = DefinitionKeySelection.Options.FirstOrDefault(opt => opt.Value.Equals(arbitraryDefinitionKey));
+            }
         }
         #endregion
 
@@ -112,6 +126,18 @@ namespace BlazorWASMAttackTable.Client.Interactions.AttackTableInteractions
                 _baseUnitValue = baseUnits;
                 CurrentArbitraryDefinition!.Value = _baseUnitValue;
             }
+        }
+
+        public void LoadToAndSelectArbitrary()
+        {
+            float _baseUnitsValue = Parameter.CurrentValue;
+
+            if (ArbitraryDefinitionSelectionOption?.IsSelected == false)
+            {
+                ArbitraryDefinitionSelectionOption.Toggle();
+            }
+
+            SetArbitraryBaseUnitsValue(_baseUnitsValue);
         }
 
         private void SetDefinitionKey(IOption<TDefinitionKey>? _)

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/FakeOptionInteraction.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/FakeOptionInteraction.cs
@@ -1,0 +1,18 @@
+﻿namespace BlazorWASMAttackTable.Client.Interactions.Options
+{
+    public class FakeOptionInteraction : IOption
+    {
+        public string OptionName { get; }
+
+        public string OptionDescription { get; }
+
+        public Action TriggerAction { get; }
+
+        public FakeOptionInteraction(string optionName, string optionDescription, Action triggerAction)
+        {
+            OptionName = optionName;
+            OptionDescription = optionDescription;
+            TriggerAction = triggerAction;
+        }
+    }
+}

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListForSingleOption.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListForSingleOption.cs
@@ -58,7 +58,9 @@ namespace BlazorWASMAttackTable.Client.Interactions.Options
         #endregion
 
         #region Constructors
-        public ListForSingleOption(IEnumerable<Option<TOption>> options, string interactionHeader, bool allowNoOption = false) : base(options, interactionHeader)
+        public ListForSingleOption(IEnumerable<Option<TOption>> options, string interactionHeader,
+            bool allowNoOption = false, IEnumerable<FakeOptionInteraction>? fakeOptionInteractions = null)
+            : base(options, interactionHeader, fakeOptionInteractions)
         {
             AllowNoOption = allowNoOption;
 

--- a/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListOfOptions.cs
+++ b/Source/VirtualAttackTable/BlazorWASMAttackTable/Client/Interactions/Options/ListOfOptions.cs
@@ -12,18 +12,18 @@
         IReadOnlyList<IOptionInteraction<TOption>> IListOfOptions<TOption>.Options => Options;
         
 
-        public IReadOnlyList<OptionInteraction<TOption>> Options
-        {
-            get;
-            private set;
-        }
+        public IReadOnlyList<OptionInteraction<TOption>> Options { get; }
+
+        public IReadOnlyList<FakeOptionInteraction> FakeOptionInteractions { get; }
         #endregion
 
         #region Constructors
-        public ListOfOptions(IEnumerable<Option<TOption>> options, string interactionHeader)
+        public ListOfOptions(IEnumerable<Option<TOption>> options, string interactionHeader, IEnumerable<FakeOptionInteraction>? fakeOptionInteractions = null)
         {
             Options = options.Select(option => new OptionInteraction<TOption>(option, ToggleOption, this)).ToList();
             InteractionHeader = interactionHeader;
+
+            FakeOptionInteractions = fakeOptionInteractions?.ToList() ?? new List<FakeOptionInteraction> { };
         }
         #endregion
 
@@ -39,6 +39,8 @@
         public string InteractionHeader { get; }
 
         IReadOnlyList<IOptionInteraction> Options { get; }
+
+        IReadOnlyList<FakeOptionInteraction> FakeOptionInteractions { get; }
     }
 
     public interface IListOfOptions<out TOption> : IListOfOptions


### PR DESCRIPTION
- Created `FakeOptionInteraction` to provide non-selectable (fake) options that fire custom actions when interacted.
- Added a list of these to `ListOfOptions`.
- Added `Save to Arbitrary` fake definition option for attack table cells. It only is present for cells with at least 2 definitions with one of them being arbitrary.
- This button writes current parameter value to the arbitrary definition and switches the definition selection to it.
- This saving uses the first arbitrary definition found in the definitions dictionary. This will cause inconsistent results if a parameter with 2 arbitrary definitions is introduced.